### PR TITLE
fix command line instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a python script that allows the user to filter SPAdes output fasta files
 To run:
 -On Windows machines, this script can be run by a double click. Otherwise, run the script using the command "python CVLFilter.py". Follow the prompts.
 -This can also be done directly using the following command:
-"python CVLFilter.py <scaffolds or contigs fasta to be filtered> <length cutoff> <coverage cutoff>"
+"python CVLFilter.py \<scaffolds or contigs fasta to be filtered\> \<length cutoff\> \<coverage cutoff\>"
 
 # CVLplot
 
@@ -14,4 +14,4 @@ This is an R script that automatically generates coverage-versus-length plots fo
 To run:
 
 -Open a command line window.
--Type "Rscript CVLplotA.R <Path to scaffolds FASTA file> <Length cutoff (in kb)> <Coverage cutoff>" and hit enter.
+-Type "Rscript CVLplotA.R \<Path to scaffolds FASTA file\> \<Length cutoff (in kb)\> \<Coverage cutoff\>" and hit enter.


### PR DESCRIPTION
The raw README.md file has the correct instruction to run:
-Type "Rscript CVLplotA.R <Path to scaffolds FASTA file> <Length cutoff (in kb)> <Coverage cutoff>" and hit enter.

But the markup interpreted it as:
-Type "Rscript CVLplotA.R <Length cutoff (in kb)>" and hit enter.

I just escaped the "<" and ">" characters in both command line instructions usin a "\"